### PR TITLE
Feature: show method for "connection refused" messages

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -210,7 +210,8 @@ class RequestsMock(object):
 
         # TODO(dcramer): find the correct class for this
         if match is None:
-            error_msg = 'Connection refused: {0}'.format(request.url)
+            error_msg = 'Connection refused: {0} {1}'.format(request.method,
+                                                             request.url)
             response = ConnectionError(error_msg)
 
             self._calls.add(request, response)


### PR DESCRIPTION
- added response method to "Connection refused" message to aid development/debugging, e.g.:
  `Connection refused: PUT http://foo.com`
